### PR TITLE
GameObject pollution fix

### DIFF
--- a/CustomEmotesAPI/CustomEmotesAPI/AnimationReplacements.cs
+++ b/CustomEmotesAPI/CustomEmotesAPI/AnimationReplacements.cs
@@ -710,7 +710,6 @@ public class BoneMapper : MonoBehaviour
         foreach (var item in startEvents)
         {
             GameObject obj = new GameObject();
-            obj = GameObject.Instantiate(obj);
             obj.transform.SetParent(transform);
             obj.transform.localPosition = new Vector3(0, -10000, 0);
             audioObjects.Add(obj);


### PR DESCRIPTION
I found this when I was using runtimeinspector alongside the mod.
I can't figure out the purpose of instantiating the gameobject that was just created without keeping a reference to the previous object or deleting it, so I'm going off the assumption that it's an error.
The issue that this line deletion solves is the pollution of the "New Game Object"s in the scene without getting deleted. The Instantiated ones are fine, since they're tucked away in a transform.
With BadAssEmotes, there's ~84 of the objects produced per compatible body, and then those get instantiated inside of the specific transform.
I don't think this causes a performance issue, but it doesn't seem correct to just leave it