### PR TITLE
Refactor dimming spheres - Fix volume on startup/scene change bug

### DIFF
--- a/CustomEmotesAPI/CustomEmotesAPI/AnimationReplacements.cs
+++ b/CustomEmotesAPI/CustomEmotesAPI/AnimationReplacements.cs
@@ -1509,6 +1509,8 @@ public class BoneMapper : MonoBehaviour
     }
     void SetRTPCInDimming(float closestDimmingSource)
     {
+        // Volume_MSX = Maser_Volume * Parent_Volume_MSX
+        // Volume_MSX is not stored as a user preference but calculated from factoring the master & music settings together
         var currentMaster = float.Parse(AudioManager.cvVolumeMaster.GetString()) / 100f;
         var actualMSX = float.Parse(AudioManager.cvVolumeParentMsx.GetString());
         if (closestDimmingSource < 20f && Settings.DimmingSpheres.Value && Settings.EmotesVolume.Value > 0)

--- a/CustomEmotesAPI/CustomEmotesAPI/AnimationReplacements.cs
+++ b/CustomEmotesAPI/CustomEmotesAPI/AnimationReplacements.cs
@@ -1513,7 +1513,6 @@ public class BoneMapper : MonoBehaviour
         var actualMSX = float.Parse(AudioManager.cvVolumeParentMsx.GetString());
         if (closestDimmingSource < 20f && Settings.DimmingSpheres.Value && Settings.EmotesVolume.Value > 0)
         {
-            DebugClass.Log("DimmingSphere: " + closestDimmingSource);
             Current_MSX = Mathf.Lerp(Current_MSX, (closestDimmingSource / 20f) * actualMSX, Time.deltaTime * 3);
             AkSoundEngine.SetRTPCValue("Volume_MSX", Current_MSX * currentMaster);
         }

--- a/CustomEmotesAPI/CustomEmotesAPI/AnimationReplacements.cs
+++ b/CustomEmotesAPI/CustomEmotesAPI/AnimationReplacements.cs
@@ -1509,21 +1509,22 @@ public class BoneMapper : MonoBehaviour
     }
     void SetRTPCInDimming(float closestDimmingSource)
     {
+        var currentMaster = float.Parse(AudioManager.cvVolumeMaster.GetString()) / 100f;
+        var actualMSX = float.Parse(AudioManager.cvVolumeParentMsx.GetString());
         if (closestDimmingSource < 20f && Settings.DimmingSpheres.Value && Settings.EmotesVolume.Value > 0)
         {
-            Current_MSX = Mathf.Lerp(Current_MSX, (closestDimmingSource / 20f) * CustomEmotesAPI.Actual_MSX, Time.deltaTime * 3);
-            AkSoundEngine.SetRTPCValue("Parent_Volume_MSX", Current_MSX);
-            AkSoundEngine.SetRTPCValue("Volume_MSX", Current_MSX);
+            DebugClass.Log("DimmingSphere: " + closestDimmingSource);
+            Current_MSX = Mathf.Lerp(Current_MSX, (closestDimmingSource / 20f) * actualMSX, Time.deltaTime * 3);
+            AkSoundEngine.SetRTPCValue("Volume_MSX", Current_MSX * currentMaster);
         }
-        else if (Current_MSX != CustomEmotesAPI.Actual_MSX)
+        else if (Current_MSX != actualMSX)
         {
-            Current_MSX = Mathf.Lerp(Current_MSX, CustomEmotesAPI.Actual_MSX, Time.deltaTime * 3);
-            if (Current_MSX + .01f > CustomEmotesAPI.Actual_MSX)
+            Current_MSX = Mathf.Lerp(Current_MSX, actualMSX, Time.deltaTime * 3);
+            if (Current_MSX + .01f > actualMSX)
             {
-                Current_MSX = CustomEmotesAPI.Actual_MSX;
+                Current_MSX = actualMSX;
             }
-            AkSoundEngine.SetRTPCValue("Parent_Volume_MSX", Current_MSX);
-            AkSoundEngine.SetRTPCValue("Volume_MSX", Current_MSX);
+            AkSoundEngine.SetRTPCValue("Volume_MSX", Current_MSX * currentMaster);
         }
     }
     void LocalFunctions()

--- a/CustomEmotesAPI/CustomEmotesAPI/CustomEmotesAPI.cs
+++ b/CustomEmotesAPI/CustomEmotesAPI/CustomEmotesAPI.cs
@@ -110,7 +110,6 @@ namespace EmotesAPI
             }
             return Input.GetKeyDown(entry.Value.MainKey);
         }
-        internal static float Actual_MSX = 69;
         public static CustomEmotesAPI instance;
         public static List<GameObject> audioContainers = new List<GameObject>();
         public static List<GameObject> activeAudioContainers = new List<GameObject>();
@@ -128,12 +127,7 @@ namespace EmotesAPI
             Register.Init();
 
             AnimationReplacements.RunAll();
-            float WhosSteveJobs = 69420;
             CreateBaseNameTokenPairs();
-            if (Settings.DontTouchThis.Value < 101)
-            {
-                WhosSteveJobs = Settings.DontTouchThis.Value;
-            }
             On.RoR2.SceneCatalog.OnActiveSceneChanged += (orig, self, scene) =>
             {
                 orig(self, scene);
@@ -144,19 +138,10 @@ namespace EmotesAPI
                     ScrollManager.SetupButtons(allClipNames);
                 }
 
-                AkSoundEngine.SetRTPCValue("Parent_Volume_MSX", Actual_MSX);
-                AkSoundEngine.SetRTPCValue("Volume_MSX", Actual_MSX);
                 for (int i = 0; i < CustomAnimationClip.syncPlayerCount.Count; i++)
                 {
                     CustomAnimationClip.syncTimer[i] = 0;
                     CustomAnimationClip.syncPlayerCount[i] = 0;
-                }
-                if (scene.name == "title" && WhosSteveJobs < 101)
-                {
-                    AkSoundEngine.SetRTPCValue("Parent_Volume_MSX", WhosSteveJobs);
-                    AkSoundEngine.SetRTPCValue("Volume_MSX", WhosSteveJobs);
-                    Actual_MSX = WhosSteveJobs;
-                    WhosSteveJobs = 69420;
                 }
                 foreach (var item in BoneMapper.allMappers)
                 {
@@ -181,29 +166,28 @@ namespace EmotesAPI
                 localMapper = null;
                 EmoteLocation.visibile = true;
             };
-            On.RoR2.AudioManager.VolumeConVar.SetString += (orig, self, newValue) =>
-            {
-                orig(self, newValue);
-                //Parent_Volume_MSX
-                try
-                {
-                    if (AkSoundEngine.IsInitialized())
-                    {
-                        if (self.GetFieldValue<string>("rtpcName") == "Parent_Volume_MSX" && WhosSteveJobs > 100)
-                        {
-                            Actual_MSX = float.Parse(newValue, CultureInfo.InvariantCulture);
-                            BoneMapper.Current_MSX = Actual_MSX;
-                            AkSoundEngine.SetRTPCValue("Parent_Volume_MSX", Actual_MSX);
-                            AkSoundEngine.SetRTPCValue("Volume_MSX", Actual_MSX);
-
-                            Settings.DontTouchThis.Value = float.Parse(newValue, CultureInfo.InvariantCulture);
-                        }
-                    }
-                }
-                catch (System.Exception)
-                {
-                }
-            };
+            // On.RoR2.AudioManager.VolumeConVar.SetString += (orig, self, newValue) =>
+            // {
+            //     orig(self, newValue);
+            //     // Parent_Volume_MSX = Music Volume
+            //     // Volume_MSX = Master Volume * Music Volume
+            //     try
+            //     {
+            //         if (AkSoundEngine.IsInitialized())
+            //         {
+            //             DebugClass.Log($"{self.GetFieldValue<string>("rtpcName")}: {newValue}");
+            //             if (self.GetFieldValue<string>("rtpcName") == "Parent_Volume_MSX")
+            //             {
+            //                 Actual_MSX = float.Parse(newValue, CultureInfo.InvariantCulture);
+            //                 BoneMapper.Current_MSX = Actual_MSX;
+            //                 AkSoundEngine.SetRTPCValue("Parent_Volume_MSX", Actual_MSX);
+            //             }
+            //         }
+            //     }
+            //     catch (System.Exception)
+            //     {
+            //     }
+            // };
             On.RoR2.PlayerCharacterMasterController.Update += (orig, self) =>
             {
                 bool emoteWheelOpen = EmoteWheel.emoteWheelKeyDown;

--- a/CustomEmotesAPI/CustomEmotesAPI/CustomEmotesAPI.cs
+++ b/CustomEmotesAPI/CustomEmotesAPI/CustomEmotesAPI.cs
@@ -166,28 +166,6 @@ namespace EmotesAPI
                 localMapper = null;
                 EmoteLocation.visibile = true;
             };
-            // On.RoR2.AudioManager.VolumeConVar.SetString += (orig, self, newValue) =>
-            // {
-            //     orig(self, newValue);
-            //     // Parent_Volume_MSX = Music Volume
-            //     // Volume_MSX = Master Volume * Music Volume
-            //     try
-            //     {
-            //         if (AkSoundEngine.IsInitialized())
-            //         {
-            //             DebugClass.Log($"{self.GetFieldValue<string>("rtpcName")}: {newValue}");
-            //             if (self.GetFieldValue<string>("rtpcName") == "Parent_Volume_MSX")
-            //             {
-            //                 Actual_MSX = float.Parse(newValue, CultureInfo.InvariantCulture);
-            //                 BoneMapper.Current_MSX = Actual_MSX;
-            //                 AkSoundEngine.SetRTPCValue("Parent_Volume_MSX", Actual_MSX);
-            //             }
-            //         }
-            //     }
-            //     catch (System.Exception)
-            //     {
-            //     }
-            // };
             On.RoR2.PlayerCharacterMasterController.Update += (orig, self) =>
             {
                 bool emoteWheelOpen = EmoteWheel.emoteWheelKeyDown;

--- a/CustomEmotesAPI/CustomEmotesAPI/Settings.cs
+++ b/CustomEmotesAPI/CustomEmotesAPI/Settings.cs
@@ -50,7 +50,6 @@ namespace EmotesAPI
         public static ConfigEntry<bool> DimmingSpheres;
         public static ConfigEntry<bool> HideJoinSpots;
         //public static ConfigEntry<bool> RemoveAutoWalk;
-        public static ConfigEntry<float> DontTouchThis;
 
         public static ConfigEntry<string> emote0;
         public static ConfigEntry<string> emote1;
@@ -187,8 +186,6 @@ namespace EmotesAPI
             emote21 = CustomEmotesAPI.instance.Config.Bind<string>("Data", "Bind for emotes21", "none", "Messing with this here is not reccomended, like at all");
             emote22 = CustomEmotesAPI.instance.Config.Bind<string>("Data", "Bind for emotes22", "none", "Messing with this here is not reccomended, like at all");
             emote23 = CustomEmotesAPI.instance.Config.Bind<string>("Data", "Bind for emotes23", "none", "Messing with this here is not reccomended, like at all");
-
-            DontTouchThis = CustomEmotesAPI.instance.Config.Bind<float>("Data", "Dont Touch This", 69420, "But like actually dont touch this");
 
             ModSettingsManager.AddOption(new GenericButtonOption("Customize Emote Wheel", "Controls", PressButton));
             ModSettingsManager.AddOption(new KeyBindOption(EmoteWheel));

--- a/CustomEmotesAPI/nuget.config
+++ b/CustomEmotesAPI/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
-    <add key="FabyDev" value="https://nuget.faby.dev/v3/index.json" />
     <add key="AAron Thunderstore" value="https://nuget.windows10ce.com/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
These changes remove the need for storing the user's music volume preference in a config variable as we no longer modify the user's preference directly. Previously Parent_Volume_MSX and Volume_MSX were being set to the same value on startup, scene change and music volume setting change which is not correct because Parent_Volume_MSX is the user's chosen music volume preference and Volume_MSX is the master volume * the music volume - the underlying final volume the music should be played at. So if the user had the master volume set to anything except 100%/1 the actual music volume would be set to be higher than expected. Resulting in bugs like these: https://streamable.com/h3krv0 https://streamable.com/zmfkh0

By instead just changing the underlying Volume_MSX factoring together the user's music setting (Parent_Volume_MSX) and their master volume setting (Master_Volume) these bugs are fixed and we no longer need to worry about preserving their music volume setting and restoring it because we no longer change it directly, only Volume_MSX which is not saved as a user preference just calculated from the 2 master and music volume options. I tested in both singleplayer and multiplayer that dimming spheres still work correctly and they seem to be exactly as intended by my testing: https://streamable.com/u6zs1n

I also removed Faby's NuGet feed from the config since it's no longer online or needed.